### PR TITLE
reordered svg plotting for nengo gui so mouse is on top

### DIFF
--- a/ccm/ui/nengo.py
+++ b/ccm/ui/nengo.py
@@ -39,6 +39,6 @@ class GridNode(nengo.Node):
             %s
             %s
             </svg>''' % (world.width, world.height, 
-                         ''.join(agents), ''.join(cells))
+                         ''.join(cells), ''.join(agents))
 
         return svg


### PR DESCRIPTION
Fixes a plotting problem I ran into when using the nengo gui plot, with the mouse not being visible.